### PR TITLE
fix: use fully qualified names in macros to remove need for glob import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ homepage = "https://github.com/plausiblelabs/lens-rs"
 repository = "https://github.com/plausiblelabs/lens-rs"
 readme = "README.md"
 
-[badges]
-travis-ci = { repository = "plausiblelabs/lens-rs" }
-
 [dependencies]
 pl-lens-derive = { path = "lens-derive", version = "1.0.0" }
 pl-lens-macros = { path = "lens-macros", version = "1.0.0" }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Rust library provides support for lenses, which are a mechanism in function
 
 ## Usage
 
-Add a dependency (or two) to your `Cargo.toml`:
+Add a dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -28,7 +28,14 @@ pl-lens = "1.0"
 Then, in your crate:
 
 ```rust
-use pl_lens::*;
+// To use the `derive(Lenses)` macro
+use pl_lens::Lenses;
+
+// To use the `lens!` macro
+use pl_lens::lens;
+
+// To bring trait methods like `get_ref` and `set` into scope
+use pl_lens::{Lens, RefLens};
 ```
 
 ## Examples

--- a/lens-derive/src/lib.rs
+++ b/lens-derive/src/lib.rs
@@ -63,7 +63,7 @@ pub fn lenses_derive(input: TokenStream) -> TokenStream {
             let value_lens = if is_primitive(&field.ty) {
                 quote!(
                     #[allow(dead_code)]
-                    impl ValueLens for #lens_name {
+                    impl pl_lens::ValueLens for #lens_name {
                         #[inline(always)]
                         fn get(&self, source: &#struct_name) -> #field_type {
                             (*source).#field_name.clone()
@@ -82,13 +82,13 @@ pub fn lenses_derive(input: TokenStream) -> TokenStream {
 
                 // Include the `Lens` impl
                 #[allow(dead_code)]
-                impl Lens for #lens_name {
+                impl pl_lens::Lens for #lens_name {
                     type Source = #struct_name;
                     type Target = #field_type;
 
                     #[inline(always)]
-                    fn path(&self) -> LensPath {
-                        LensPath::new(#field_index)
+                    fn path(&self) -> pl_lens::LensPath {
+                        pl_lens::LensPath::new(#field_index)
                     }
 
                     #[inline(always)]
@@ -99,7 +99,7 @@ pub fn lenses_derive(input: TokenStream) -> TokenStream {
 
                 // Include the `RefLens` impl
                 #[allow(dead_code)]
-                impl RefLens for #lens_name {
+                impl pl_lens::RefLens for #lens_name {
                     #[inline(always)]
                     fn get_ref<'a>(&self, source: &'a #struct_name) -> &'a #field_type {
                         &(*source).#field_name

--- a/lens-macros/src/lib.rs
+++ b/lens-macros/src/lib.rs
@@ -75,7 +75,7 @@ pub fn lens(input: TokenStream) -> TokenStream {
 
     // Build the output
     let expanded = quote! {
-        compose_lens!(#(#lens_exprs),*);
+        pl_lens::compose_lens!(#(#lens_exprs),*);
     };
 
     // Hand the output tokens back to the compiler

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 // All rights reserved.
 //
 
+extern crate self as pl_lens;
+
 use proc_macro_hack::proc_macro_hack;
 
 // Re-export the pl-lens-derive crate

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,6 +10,6 @@ macro_rules! compose_lens {
         $head
     };
     { $head:expr, $($tail:expr),+ } => {
-        compose($head, compose_lens!($($tail),+))
+        pl_lens::compose($head, pl_lens::compose_lens!($($tail),+))
     };
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,7 +3,7 @@
 // All rights reserved.
 //
 
-use pl_lens::*;
+use pl_lens::Lenses;
 
 #[derive(Lenses)]
 struct Address {
@@ -21,6 +21,8 @@ struct Person {
 
 #[test]
 fn a_simple_nested_data_structure_should_be_lensable() {
+    use pl_lens::{lens, Lens, RefLens};
+
     let p0 = Person {
         name: "Pop Zeus".to_string(),
         age: 58,


### PR DESCRIPTION
Fixes #7 