### PR TITLE
Apply source visibility to lens fields

### DIFF
--- a/lens-derive/src/lib.rs
+++ b/lens-derive/src/lib.rs
@@ -130,6 +130,11 @@ pub fn lenses_derive(input: TokenStream) -> TokenStream {
     //     }
     let lenses_struct_name = format_ident!("{}Lenses", struct_name);
     let lenses_struct_fields = fields.iter().map(|field| {
+        let field_visibility = match field.vis {
+            Visibility::Public(..) => quote!(pub),
+            _ => quote!(), // default to private for now
+        };
+
         if let Some(field_name) = &field.ident {
             let field_lens_name = format_ident!(
                 "{}{}Lens",
@@ -137,14 +142,14 @@ pub fn lenses_derive(input: TokenStream) -> TokenStream {
                 to_camel_case(&field_name.to_string())
             );
             if is_primitive(&field.ty) {
-                quote!(#field_name: #field_lens_name)
+                quote!(#field_visibility #field_name: #field_lens_name)
             } else {
                 let field_parent_lenses_field_name = format_ident!("{}_lenses", field_name);
                 let field_parent_lenses_type_name =
                     format_ident!("{}Lenses", to_camel_case(&field_name.to_string()));
                 quote!(
-                    #field_name: #field_lens_name,
-                    #field_parent_lenses_field_name: #field_parent_lenses_type_name
+                    #field_visibility #field_name: #field_lens_name,
+                    #field_visibility #field_parent_lenses_field_name: #field_parent_lenses_type_name
                 )
             }
         } else {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,6 +10,7 @@ struct Address {
     street: String,
     city: String,
     postcode: String,
+    #[leaf] names: Vec<String>
 }
 
 #[derive(Lenses)]
@@ -30,6 +31,7 @@ fn a_simple_nested_data_structure_should_be_lensable() {
             street: "123 Needmore Rd".to_string(),
             city: "Dayton".to_string(),
             postcode: "99999".to_string(),
+            names: vec!["a".into(),"vec".into()],
         },
     };
     assert_eq!(lens!(Person.name).get_ref(&p0), "Pop Zeus");


### PR DESCRIPTION
Lens fields were always private, which prevented using the lenses in places where visibility matters. This is intended to copy the field visibility from the source file and apply it to the lens field. I am not experienced with derive macros, so this is basically just adapted from code earlier in this file for the struct visibility, but it appears to solve the problem I was having.